### PR TITLE
Filter hooks through wp_kses_post if user is not permitted to submit unfiltered_html to site

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -63,7 +63,9 @@ function simplehooks_form_generate( $args = array() ) {
 
 	<p>
 		<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]" value="1" <?php checked( 1, simplehooks_get_option( $args['hook'], 'shortcodes' ) ); ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]"><?php _e( 'Execute Shortcodes on this hook?', 'simplehooks' ); ?></label><br />
+		<?php if( current_user_can('unfiltered_html')) : ?>
 		<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]" value="1" <?php checked( 1, simplehooks_get_option( $args['hook'], 'php' ) ); ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]"><?php _e( 'Execute PHP on this hook?', 'simplehooks' ); ?></label>
+		<?php endif; ?>
 	</p>
 
 	<hr class="div" />

--- a/plugin.php
+++ b/plugin.php
@@ -125,3 +125,24 @@ function simplehooks_execute_hook() {
 		echo $value;
 
 }
+
+/**
+ * The following function will strip unpermitted html tags such as scripts
+ * from the user submitted hook content if that user is not permitted to 
+ * submit unfiltered html on the content
+ *
+ * @since 2.0.1
+ */
+function simplehooks_maybe_kses_filter($option){
+	if(!current_user_can('unfiltered_html')){
+
+		foreach($option as $key => $value){
+			if($value == '')
+				continue;
+			$option[$key]['content'] = wp_kses_post($value['content']);
+		}
+	}
+	return $option;	
+}
+
+add_filter('pre_update_option_'.SIMPLEHOOKS_SETTINGS_FIELD, 'simplehooks_maybe_kses_filter');


### PR DESCRIPTION
We wish to use this plugin on our multisite however for security reasons we do not permit users to add scripts to their content.  This filters the hook content and removes unpermitted html tags if the user does not have the unfiltered_html capability.  This will not effect most users using the plugin already on single site installations since site administrators on single sites do have the unfiltered_html capability.

This also prevent PHP from being entered. 
