### PR TITLE
Allow user to omit the closing ?>

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -120,7 +120,7 @@ function simplehooks_execute_hook() {
 	$value = $shortcodes ? do_shortcode( $content ) : $content;
 
 	if ( $php )
-		eval( "?>$value<?php " );
+		eval( "?>$value" );
 	else
 		echo $value;
 


### PR DESCRIPTION
Currently, if the user selects 'Execute PHP', they are required to include the closing `?>`. This change allows them to either include it or omit it.
