### PR TITLE
Complete the i18n support, add default .pot file

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -27,8 +27,8 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 		$menu_ops = array(
 			'submenu' => array(
 				'parent_slug' => 'genesis',
-				'page_title'  => __( 'Genesis - Simple Hooks', 'simplehooks' ),
-				'menu_title'  => __( 'Simple Hooks', 'simplehooks' )
+				'page_title'  => __( 'Genesis - Simple Hooks', 'genesis-simple-hooks' ),
+				'menu_title'  => __( 'Simple Hooks', 'genesis-simple-hooks' )
 			)
 		);
 
@@ -178,23 +178,23 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
  	 */
 	function metaboxes() {
 
-		add_meta_box( 'simplehooks-wp-hooks', __( 'WordPress Hooks', 'simplehooks' ), array( $this, 'wp_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-document-hooks', __( 'Document Hooks', 'simplehooks' ), array( $this, 'document_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-header-hooks', __( 'Header Hooks', 'simplehooks' ), array( $this, 'header_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-content-hooks', __( 'Content Hooks', 'simplehooks' ), array( $this, 'content_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-loop-hooks', __( 'Loop Hooks', 'simplehooks' ), array( $this, 'loop_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-wp-hooks', __( 'WordPress Hooks', 'genesis-simple-hooks' ), array( $this, 'wp_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-document-hooks', __( 'Document Hooks', 'genesis-simple-hooks' ), array( $this, 'document_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-header-hooks', __( 'Header Hooks', 'genesis-simple-hooks' ), array( $this, 'header_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-content-hooks', __( 'Content Hooks', 'genesis-simple-hooks' ), array( $this, 'content_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-loop-hooks', __( 'Loop Hooks', 'genesis-simple-hooks' ), array( $this, 'loop_hooks_box' ), $this->pagehook, 'main' );
 		
 		if ( current_theme_supports( 'html5' ) )
-			add_meta_box( 'simplehooks-entry-hooks', __( 'Entry Hooks', 'simplehooks' ), array( $this, 'html5_entry_hooks_box' ), $this->pagehook, 'main' );
+			add_meta_box( 'simplehooks-entry-hooks', __( 'Entry Hooks', 'genesis-simple-hooks' ), array( $this, 'html5_entry_hooks_box' ), $this->pagehook, 'main' );
 		else
-			add_meta_box( 'simplehooks-post-hooks', __( 'Post/Page Hooks', 'simplehooks' ), array( $this, 'post_hooks_box' ), $this->pagehook, 'main' );
+			add_meta_box( 'simplehooks-post-hooks', __( 'Post/Page Hooks', 'genesis-simple-hooks' ), array( $this, 'post_hooks_box' ), $this->pagehook, 'main' );
 		
-		add_meta_box( 'simplehooks-comment-list-hooks', __( 'Comment List Hooks', 'simplehooks' ), array( $this, 'comment_list_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-ping-list-hooks', __( 'Ping List Hooks', 'simplehooks' ), array( $this, 'ping_list_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-comment-hooks', __( 'Single Comment Hooks', 'simplehooks' ), array( $this, 'comment_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-comment-form-hooks', __( 'Comment Form Hooks', 'simplehooks' ), array( $this, 'comment_form_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-sidebar-hooks', __( 'Sidebar Hooks', 'simplehooks' ), array( $this, 'sidebar_hooks_box' ), $this->pagehook, 'main' );
-		add_meta_box( 'simplehooks-footer-hooks', __( 'Footer Hooks', 'simplehooks' ), array( $this, 'footer_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-comment-list-hooks', __( 'Comment List Hooks', 'genesis-simple-hooks' ), array( $this, 'comment_list_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-ping-list-hooks', __( 'Ping List Hooks', 'genesis-simple-hooks' ), array( $this, 'ping_list_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-comment-hooks', __( 'Single Comment Hooks', 'genesis-simple-hooks' ), array( $this, 'comment_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-comment-form-hooks', __( 'Comment Form Hooks', 'genesis-simple-hooks' ), array( $this, 'comment_form_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-sidebar-hooks', __( 'Sidebar Hooks', 'genesis-simple-hooks' ), array( $this, 'sidebar_hooks_box' ), $this->pagehook, 'main' );
+		add_meta_box( 'simplehooks-footer-hooks', __( 'Footer Hooks', 'genesis-simple-hooks' ), array( $this, 'footer_hooks_box' ), $this->pagehook, 'main' );
 
 	}
 	
@@ -202,16 +202,16 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'wp_head',
-			'desc' => __( 'This hook executes immediately before the closing <code>&lt;/head&gt;</code> tag.', 'simplehooks' ),
+			'desc' => __( 'This hook executes immediately before the closing <code>&lt;/head&gt;</code> tag.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_load_favicon' ),
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'wp_footer',
-			'desc' => __( 'This hook executes immediately before the closing <code>&lt;/body&gt;</code> tag.', 'simplehooks' ),
+			'desc' => __( 'This hook executes immediately before the closing <code>&lt;/body&gt;</code> tag.', 'genesis-simple-hooks' ),
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -219,25 +219,25 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_title',
-			'desc' => __( 'This hook executes between the main document <code>&lt;title&gt;&lt;/title&gt;</code> tags.', 'simplehooks' )
+			'desc' => __( 'This hook executes between the main document <code>&lt;title&gt;&lt;/title&gt;</code> tags.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_meta',
-			'desc' => __( 'This hook executes in the document <code>&lt;head&gt;</code>.<br /> It is commonly used to output <code>META</code> information about the document.', 'simplehooks' ),
+			'desc' => __( 'This hook executes in the document <code>&lt;head&gt;</code>.<br /> It is commonly used to output <code>META</code> information about the document.', 'genesis-simple-hooks' ),
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before',
-			'desc' => __( 'This hook executes immediately after the opening <code>&lt;body&gt;</code> tag.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the opening <code>&lt;body&gt;</code> tag.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after',
-			'desc' => __( 'This hook executes immediately before the closing <code>&lt;/body&gt;</code> tag.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the closing <code>&lt;/body&gt;</code> tag.', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -245,18 +245,18 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_header',
-			'desc' => __( 'This hook executes immediately before the header.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the header.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_header',
-			'desc' => __( 'This hook outputs the default header.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the default header.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_header' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_header',
-			'desc' => __( 'This hook executes immediately after the header.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the header.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
@@ -271,7 +271,7 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 			'unhook' => array( 'genesis_seo_site_description' ),
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -279,25 +279,25 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_content_sidebar_wrap',
-			'desc' => __( 'This hook executes immediately before the div block that wraps the content and the primary sidebar.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the div block that wraps the content and the primary sidebar.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_content_sidebar_wrap',
-			'desc' => __( 'This hook executes immediately after the div block that wraps the content and the primary sidebar.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the div block that wraps the content and the primary sidebar.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_content',
-			'desc' => __( 'This hook executes immediately before the content column.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the content column.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_content',
-			'desc' => __( 'This hook executes immediately after the content column.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the content column.', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -305,33 +305,33 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_loop',
-			'desc' => __( 'This hook executes immediately before all loop blocks.<br /> Therefore, this hook falls outside the loop, and cannot execute functions that require loop template tags or variables.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before all loop blocks.<br /> Therefore, this hook falls outside the loop, and cannot execute functions that require loop template tags or variables.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_loop',
-			'desc' => __( 'This hook executes both default and custom loops.', 'simplehooks' ),
+			'desc' => __( 'This hook executes both default and custom loops.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_loop' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_loop',
-			'desc' => __( 'This hook executes immediately after all loop blocks.<br /> Therefore, this hook falls outside the loop, and cannot execute functions that require loop template tags or variables.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after all loop blocks.<br /> Therefore, this hook falls outside the loop, and cannot execute functions that require loop template tags or variables.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_endwhile',
-			'desc' => __( 'This hook executes after the <code>endwhile;</code> statement.', 'simplehooks' ),
+			'desc' => __( 'This hook executes after the <code>endwhile;</code> statement.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_posts_nav' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_loop_else',
-			'desc' => __( 'This hook executes after the <code>else :</code> statement in all loop blocks. The content attached to this hook will only display if there are no posts available when a loop is executed.', 'simplehooks' ),
+			'desc' => __( 'This hook executes after the <code>else :</code> statement in all loop blocks. The content attached to this hook will only display if there are no posts available when a loop is executed.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_noposts' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -339,30 +339,30 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate(array(
 			'hook' => 'genesis_before_entry',
-			'desc' => __( 'This hook executes before each entry in all loop blocks (outside the entry markup element).', 'simplehooks' )
+			'desc' => __( 'This hook executes before each entry in all loop blocks (outside the entry markup element).', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate(array(
 			'hook' => 'genesis_entry_header',
-			'desc' => __( 'This hook executes before the entry content. By default, it outputs the entry title and meta information.', 'simplehooks' )
+			'desc' => __( 'This hook executes before the entry content. By default, it outputs the entry title and meta information.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate(array(
 			'hook' => 'genesis_entry_content',
-			'desc' => __( 'This hook, by default, outputs the entry content.', 'simplehooks' )
+			'desc' => __( 'This hook, by default, outputs the entry content.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate(array(
 			'hook' => 'genesis_entry_footer',
-			'desc' => __( 'This hook executes after the entry content. By Default, it outputs entry meta information.', 'simplehooks' )
+			'desc' => __( 'This hook executes after the entry content. By Default, it outputs entry meta information.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate(array(
 			'hook' => 'genesis_after_entry',
-			'desc' => __( 'This hook executes after each entry in all loop blocks (outside the entry markup element).', 'simplehooks' )
+			'desc' => __( 'This hook executes after each entry in all loop blocks (outside the entry markup element).', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -370,50 +370,50 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_post',
-			'desc' => __( 'This hook executes before each post in all loop blocks (outside the <code>post_class()</code> div).', 'simplehooks' )
+			'desc' => __( 'This hook executes before each post in all loop blocks (outside the <code>post_class()</code> div).', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_post',
-			'desc' => __( 'This hook executes after each post in all loop blocks (outside the <code>post_class()</code> div).', 'simplehooks' ),
+			'desc' => __( 'This hook executes after each post in all loop blocks (outside the <code>post_class()</code> div).', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_author_box' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_post_title',
-			'desc' => __( 'This hook executes immediately before each post/page title within the loop.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before each post/page title within the loop.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_post_title',
-			'desc' => __( 'This hook outputs the post/page title.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the post/page title.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_post_title' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_post_title',
-			'desc' => __( 'This hook executes immediately after each post/page title within the loop.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after each post/page title within the loop.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_post_content',
-			'desc' => __( 'This hook executes immediately before the <code>genesis_post_content</code> hook for each post/page within the loop.', 'simplehooks' ),
+			'desc' => __( 'This hook executes immediately before the <code>genesis_post_content</code> hook for each post/page within the loop.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_post_info' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_post_content',
-			'desc' => __( 'This hook outputs the content of the post/page, by default.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the content of the post/page, by default.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_post_image', 'genesis_do_post_content' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_post_content',
-			'desc' => __( 'This hook executes immediately after the <code>genesis_post_content</code> hook for each post/page within the loop.', 'simplehooks' ),
+			'desc' => __( 'This hook executes immediately after the <code>genesis_post_content</code> hook for each post/page within the loop.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_post_meta' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -421,24 +421,24 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_comments',
-			'desc' => __( 'This hook executes immediately before the comments block.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the comments block.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_comments',
-			'desc' => __( 'This hook outputs the comments block.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the comments block.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_comments' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_list_comments',
-			'desc' => __( 'This hook executes inside the comments block. By default, it outputs a list of comments associated with a post via the <code>genesis_default_list_comments()</code> function.', 'simplehooks' ),
+			'desc' => __( 'This hook executes inside the comments block. By default, it outputs a list of comments associated with a post via the <code>genesis_default_list_comments()</code> function.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_default_list_comments' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_comments',
-			'desc' => __( 'This hook executes immediately after the comments block.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the comments block.', 'genesis-simple-hooks' )
 		) );
 
 	}
@@ -447,27 +447,27 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_pings',
-			'desc' => __( 'This hook executes immediately before the pings block.', 'simplehooks' ),
+			'desc' => __( 'This hook executes immediately before the pings block.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_pings' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_pings',
-			'desc' => __( 'This hook outputs the pings block.', 'simplehooks' )
+			'desc' => __( 'This hook outputs the pings block.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_list_pings',
-			'desc' => __( 'This hook executes inside the pings block. By default, it outputs a list of pings associated with a post via the <code>genesis_default_list_pings()</code> function.', 'simplehooks' ),
+			'desc' => __( 'This hook executes inside the pings block. By default, it outputs a list of pings associated with a post via the <code>genesis_default_list_pings()</code> function.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_default_list_pings' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_pings',
-			'desc' => __( 'This hook executes immediately after the pings block.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the pings block.', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -475,15 +475,15 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_comment',
-			'desc' => __( 'This hook executes immediately before each individual comment (inside the <code>.comment</code> list item).', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before each individual comment (inside the <code>.comment</code> list item).', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_comment',
-			'desc' => __( 'This hook executes immediately after each individual comment (inside the <code>.comment</code> list item).', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after each individual comment (inside the <code>.comment</code> list item).', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -491,21 +491,21 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_comment_form',
-			'desc' => __( 'This hook executes immediately before the comment form.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the comment form.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_comment_form',
-			'desc' => __( 'This hook outputs the entire comment form.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the entire comment form.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_comment_form' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_comment_form',
-			'desc' => __( 'This hook executes immediately after the comment form.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the comment form.', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -513,57 +513,57 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_sidebar',
-			'desc' => __( 'This hook executes immediately before the primary sidebar column.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the primary sidebar column.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_sidebar',
-			'desc' => __( 'This hook outputs the content of the primary sidebar, including the widget area output.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the content of the primary sidebar, including the widget area output.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_sidebar' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_sidebar',
-			'desc' => __( 'This hook executes immediately after the primary sidebar column.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the primary sidebar column.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_sidebar_widget_area',
-			'desc' => __( 'This hook executes immediately before the primary sidebar widget area.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the primary sidebar widget area.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_sidebar_widget_area',
-			'desc' => __( 'This hook executes immediately after the primary sidebar widget area.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the primary sidebar widget area.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_sidebar_alt',
-			'desc' => __( 'This hook executes immediately before the alternate sidebar column.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the alternate sidebar column.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_sidebar_alt',
-			'desc' => __( 'This hook outputs the content of the secondary sidebar, including the widget area output.', 'simplehooks' ),
+			'desc' => __( 'This hook outputs the content of the secondary sidebar, including the widget area output.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_sidebar_alt' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_sidebar_alt',
-			'desc' => __( 'This hook executes immediately after the alternate sidebar column.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the alternate sidebar column.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_sidebar_alt_widget_area',
-			'desc' => __( 'This hook executes immediately before the alternate sidebar widget area.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the alternate sidebar widget area.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_sidebar_alt_widget_area',
-			'desc' => __( 'This hook executes immediately after the alternate sidebar widget area.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the alternate sidebar widget area.', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 
@@ -571,21 +571,21 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_footer',
-			'desc' => __( 'This hook executes immediately before the footer.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately before the footer.', 'genesis-simple-hooks' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_footer',
-			'desc' => __( 'This hook, by default, outputs the content of the footer.', 'simplehooks' ),
+			'desc' => __( 'This hook, by default, outputs the content of the footer.', 'genesis-simple-hooks' ),
 			'unhook' => array( 'genesis_do_footer' )
 		) );
 
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_footer',
-			'desc' => __( 'This hook executes immediately after the footer.', 'simplehooks' )
+			'desc' => __( 'This hook executes immediately after the footer.', 'genesis-simple-hooks' )
 		) );
 
-		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
+		submit_button( __( 'Save Changes', 'genesis-simple-hooks' ), 'primary' );
 
 	}
 	

--- a/functions.php
+++ b/functions.php
@@ -42,7 +42,7 @@ function simplehooks_form_generate( $args = array() ) {
 
 ?>
 
-	<h4><code><?php echo $args['hook']; ?></code> <?php _e( 'Hook', 'simplehooks' ); ?></h4>
+	<h4><code><?php echo $args['hook']; ?></code> <?php _e( 'Hook', 'genesis-simple-hooks' ); ?></h4>
 	<p><span class="description"><?php echo $args['desc']; ?></span></p>
 
 	<?php
@@ -51,7 +51,7 @@ function simplehooks_form_generate( $args = array() ) {
 			foreach ( (array) $args['unhook'] as $function ) {
 			?>
 
-				<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" value="<?php echo $function; ?>" <?php if ( in_array( $function, (array) simplehooks_get_option( $args['hook'], 'unhook' ) ) ) echo 'checked'; ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]"><?php printf( __( 'Unhook <code>%s()</code> function from this hook?', 'simplehooks' ), $function ); ?></label><br />
+				<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" value="<?php echo $function; ?>" <?php if ( in_array( $function, (array) simplehooks_get_option( $args['hook'], 'unhook' ) ) ) echo 'checked'; ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]"><?php printf( __( 'Unhook %s function from this hook?', 'genesis-simple-hooks' ), '<code>' . $function . '()</code>' ); ?></label><br />
 
 			<?php
 			}
@@ -62,8 +62,8 @@ function simplehooks_form_generate( $args = array() ) {
 	<p><textarea name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][content]" cols="70" rows="5"><?php echo htmlentities( simplehooks_get_option( $args['hook'], 'content' ), ENT_QUOTES, 'UTF-8' ); ?></textarea></p>
 
 	<p>
-		<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]" value="1" <?php checked( 1, simplehooks_get_option( $args['hook'], 'shortcodes' ) ); ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]"><?php _e( 'Execute Shortcodes on this hook?', 'simplehooks' ); ?></label><br />
-		<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]" value="1" <?php checked( 1, simplehooks_get_option( $args['hook'], 'php' ) ); ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]"><?php _e( 'Execute PHP on this hook?', 'simplehooks' ); ?></label>
+		<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]" value="1" <?php checked( 1, simplehooks_get_option( $args['hook'], 'shortcodes' ) ); ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][shortcodes]"><?php _e( 'Execute Shortcodes on this hook?', 'genesis-simple-hooks' ); ?></label><br />
+		<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]" value="1" <?php checked( 1, simplehooks_get_option( $args['hook'], 'php' ) ); ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][php]"><?php _e( 'Execute PHP on this hook?', 'genesis-simple-hooks' ); ?></label>
 	</p>
 
 	<hr class="div" />

--- a/languages/genesis-simple-hooks.pot
+++ b/languages/genesis-simple-hooks.pot
@@ -1,0 +1,424 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Genesis Simple Hooks\n"
+"POT-Creation-Date: 2015-05-27 12:48+0100\n"
+"PO-Revision-Date: 2015-05-27 12:48+0100\n"
+"Last-Translator: David Decker DECKERWEB.de -- http://deckerweb.de/\n"
+"Language-Team: David Decker DECKERWEB.de -- http://deckerweb.de/\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-WPHeader: plugin.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
+
+#: admin.php:30
+msgid "Genesis - Simple Hooks"
+msgstr ""
+
+#: admin.php:31
+msgid "Simple Hooks"
+msgstr ""
+
+#: admin.php:181
+msgid "WordPress Hooks"
+msgstr ""
+
+#: admin.php:182
+msgid "Document Hooks"
+msgstr ""
+
+#: admin.php:183
+msgid "Header Hooks"
+msgstr ""
+
+#: admin.php:184
+msgid "Content Hooks"
+msgstr ""
+
+#: admin.php:185
+msgid "Loop Hooks"
+msgstr ""
+
+#: admin.php:188
+msgid "Entry Hooks"
+msgstr ""
+
+#: admin.php:190
+msgid "Post/Page Hooks"
+msgstr ""
+
+#: admin.php:192
+msgid "Comment List Hooks"
+msgstr ""
+
+#: admin.php:193
+msgid "Ping List Hooks"
+msgstr ""
+
+#: admin.php:194
+msgid "Single Comment Hooks"
+msgstr ""
+
+#: admin.php:195
+msgid "Comment Form Hooks"
+msgstr ""
+
+#: admin.php:196
+msgid "Sidebar Hooks"
+msgstr ""
+
+#: admin.php:197
+msgid "Footer Hooks"
+msgstr ""
+
+#: admin.php:205
+msgid ""
+"This hook executes immediately before the closing <code>&lt;/head&gt;</code> "
+"tag."
+msgstr ""
+
+#: admin.php:211 admin.php:237
+msgid ""
+"This hook executes immediately before the closing <code>&lt;/body&gt;</code> "
+"tag."
+msgstr ""
+
+#: admin.php:214 admin.php:240 admin.php:274 admin.php:300 admin.php:334
+#: admin.php:365 admin.php:416 admin.php:470 admin.php:486 admin.php:508
+#: admin.php:566 admin.php:588
+msgid "Save Changes"
+msgstr ""
+
+#: admin.php:222
+msgid ""
+"This hook executes between the main document <code>&lt;title&gt;&lt;/"
+"title&gt;</code> tags."
+msgstr ""
+
+#: admin.php:227
+msgid ""
+"This hook executes in the document <code>&lt;head&gt;</code>.<br /> It is "
+"commonly used to output <code>META</code> information about the document."
+msgstr ""
+
+#: admin.php:232
+msgid ""
+"This hook executes immediately after the opening <code>&lt;body&gt;</code> "
+"tag."
+msgstr ""
+
+#: admin.php:248
+msgid "This hook executes immediately before the header."
+msgstr ""
+
+#: admin.php:253
+msgid "This hook outputs the default header."
+msgstr ""
+
+#: admin.php:259
+msgid "This hook executes immediately after the header."
+msgstr ""
+
+#: admin.php:264
+msgid ""
+"This hooks executes inside the header, and by default, outputs the site "
+"title."
+msgstr ""
+
+#: admin.php:270
+msgid ""
+"This hooks executes inside the header, and by default, outputs the site "
+"description."
+msgstr ""
+
+#: admin.php:282
+msgid ""
+"This hook executes immediately before the div block that wraps the content "
+"and the primary sidebar."
+msgstr ""
+
+#: admin.php:287
+msgid ""
+"This hook executes immediately after the div block that wraps the content "
+"and the primary sidebar."
+msgstr ""
+
+#: admin.php:292
+msgid "This hook executes immediately before the content column."
+msgstr ""
+
+#: admin.php:297
+msgid "This hook executes immediately after the content column."
+msgstr ""
+
+#: admin.php:308
+msgid ""
+"This hook executes immediately before all loop blocks.<br /> Therefore, this "
+"hook falls outside the loop, and cannot execute functions that require loop "
+"template tags or variables."
+msgstr ""
+
+#: admin.php:313
+msgid "This hook executes both default and custom loops."
+msgstr ""
+
+#: admin.php:319
+msgid ""
+"This hook executes immediately after all loop blocks.<br /> Therefore, this "
+"hook falls outside the loop, and cannot execute functions that require loop "
+"template tags or variables."
+msgstr ""
+
+#: admin.php:324
+msgid "This hook executes after the <code>endwhile;</code> statement."
+msgstr ""
+
+#: admin.php:330
+msgid ""
+"This hook executes after the <code>else :</code> statement in all loop "
+"blocks. The content attached to this hook will only display if there are no "
+"posts available when a loop is executed."
+msgstr ""
+
+#: admin.php:342
+msgid ""
+"This hook executes before each entry in all loop blocks (outside the entry "
+"markup element)."
+msgstr ""
+
+#: admin.php:347
+msgid ""
+"This hook executes before the entry content. By default, it outputs the "
+"entry title and meta information."
+msgstr ""
+
+#: admin.php:352
+msgid "This hook, by default, outputs the entry content."
+msgstr ""
+
+#: admin.php:357
+msgid ""
+"This hook executes after the entry content. By Default, it outputs entry "
+"meta information."
+msgstr ""
+
+#: admin.php:362
+msgid ""
+"This hook executes after each entry in all loop blocks (outside the entry "
+"markup element)."
+msgstr ""
+
+#: admin.php:373
+msgid ""
+"This hook executes before each post in all loop blocks (outside the "
+"<code>post_class()</code> div)."
+msgstr ""
+
+#: admin.php:378
+msgid ""
+"This hook executes after each post in all loop blocks (outside the "
+"<code>post_class()</code> div)."
+msgstr ""
+
+#: admin.php:384
+msgid ""
+"This hook executes immediately before each post/page title within the loop."
+msgstr ""
+
+#: admin.php:389
+msgid "This hook outputs the post/page title."
+msgstr ""
+
+#: admin.php:395
+msgid ""
+"This hook executes immediately after each post/page title within the loop."
+msgstr ""
+
+#: admin.php:400
+msgid ""
+"This hook executes immediately before the <code>genesis_post_content</code> "
+"hook for each post/page within the loop."
+msgstr ""
+
+#: admin.php:406
+msgid "This hook outputs the content of the post/page, by default."
+msgstr ""
+
+#: admin.php:412
+msgid ""
+"This hook executes immediately after the <code>genesis_post_content</code> "
+"hook for each post/page within the loop."
+msgstr ""
+
+#: admin.php:424
+msgid "This hook executes immediately before the comments block."
+msgstr ""
+
+#: admin.php:429
+msgid "This hook outputs the comments block."
+msgstr ""
+
+#: admin.php:435
+msgid ""
+"This hook executes inside the comments block. By default, it outputs a list "
+"of comments associated with a post via the "
+"<code>genesis_default_list_comments()</code> function."
+msgstr ""
+
+#: admin.php:441
+msgid "This hook executes immediately after the comments block."
+msgstr ""
+
+#: admin.php:450
+msgid "This hook executes immediately before the pings block."
+msgstr ""
+
+#: admin.php:456
+msgid "This hook outputs the pings block."
+msgstr ""
+
+#: admin.php:461
+msgid ""
+"This hook executes inside the pings block. By default, it outputs a list of "
+"pings associated with a post via the <code>genesis_default_list_pings()</"
+"code> function."
+msgstr ""
+
+#: admin.php:467
+msgid "This hook executes immediately after the pings block."
+msgstr ""
+
+#: admin.php:478
+msgid ""
+"This hook executes immediately before each individual comment (inside the "
+"<code>.comment</code> list item)."
+msgstr ""
+
+#: admin.php:483
+msgid ""
+"This hook executes immediately after each individual comment (inside the "
+"<code>.comment</code> list item)."
+msgstr ""
+
+#: admin.php:494
+msgid "This hook executes immediately before the comment form."
+msgstr ""
+
+#: admin.php:499
+msgid "This hook outputs the entire comment form."
+msgstr ""
+
+#: admin.php:505
+msgid "This hook executes immediately after the comment form."
+msgstr ""
+
+#: admin.php:516
+msgid "This hook executes immediately before the primary sidebar column."
+msgstr ""
+
+#: admin.php:521
+msgid ""
+"This hook outputs the content of the primary sidebar, including the widget "
+"area output."
+msgstr ""
+
+#: admin.php:527
+msgid "This hook executes immediately after the primary sidebar column."
+msgstr ""
+
+#: admin.php:532
+msgid "This hook executes immediately before the primary sidebar widget area."
+msgstr ""
+
+#: admin.php:537
+msgid "This hook executes immediately after the primary sidebar widget area."
+msgstr ""
+
+#: admin.php:542
+msgid "This hook executes immediately before the alternate sidebar column."
+msgstr ""
+
+#: admin.php:547
+msgid ""
+"This hook outputs the content of the secondary sidebar, including the widget "
+"area output."
+msgstr ""
+
+#: admin.php:553
+msgid "This hook executes immediately after the alternate sidebar column."
+msgstr ""
+
+#: admin.php:558
+msgid ""
+"This hook executes immediately before the alternate sidebar widget area."
+msgstr ""
+
+#: admin.php:563
+msgid "This hook executes immediately after the alternate sidebar widget area."
+msgstr ""
+
+#: admin.php:574
+msgid "This hook executes immediately before the footer."
+msgstr ""
+
+#: admin.php:579
+msgid "This hook, by default, outputs the content of the footer."
+msgstr ""
+
+#: admin.php:585
+msgid "This hook executes immediately after the footer."
+msgstr ""
+
+#: functions.php:45
+msgid "Hook"
+msgstr ""
+
+#: functions.php:54
+#, php-format
+msgid "Unhook %s function from this hook?"
+msgstr ""
+
+#: functions.php:65
+msgid "Execute Shortcodes on this hook?"
+msgstr ""
+
+#: functions.php:66
+msgid "Execute PHP on this hook?"
+msgstr ""
+
+#: plugin.php:83
+#, php-format
+msgid ""
+"Sorry, you cannot run Simple Hooks without WordPress %s and <a href=\"%s"
+"\">Genesis %s</a>, or greater."
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Genesis Simple Hooks"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "http://www.studiopress.com/plugins/simple-hooks"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Genesis Simple Hooks allows you easy access to the 50+ Action Hooks in the "
+"Genesis Theme."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Nathan Rice"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://www.nathanrice.net/"
+msgstr ""

--- a/plugin.php
+++ b/plugin.php
@@ -12,11 +12,55 @@
 
 	License: GNU General Public License v2.0 (or later)
 	License URI: http://www.opensource.org/licenses/gpl-license.php
+
+	Text Domain: genesis-simple-hooks
+	Domain Path: /languages/
 */
 
 //* Define our constants
 define( 'SIMPLEHOOKS_SETTINGS_FIELD', 'simplehooks-settings' );
 define( 'SIMPLEHOOKS_PLUGIN_DIR', dirname( __FILE__ ) );
+
+add_action( 'plugins_loaded', 'simplehooks_load_translations', 1 );
+/**
+ * Load the text domain for translation of the plugin.
+ * Needs to be fired early on to catch all strings in the admin.
+ * 
+ * @since 2.1.1
+ */
+function simplehooks_load_translations() {
+
+	/** Set unique textdomain string */
+	$sh_textdomain = 'genesis-simple-hooks';
+
+	/** The 'plugin_locale' filter is also used by default in load_plugin_textdomain() */
+	$locale = apply_filters( 'plugin_locale', get_locale(), $sh_textdomain );
+
+	/** Set filter for WordPress languages directory */
+	$sh_wp_lang_dir = apply_filters(
+		'simplehooks_wp_lang_dir',
+		trailingslashit( WP_LANG_DIR ) . 'plugins/' . $sh_textdomain . '-' . $locale . '.mo'
+	);
+
+	/** We only need translations within wp-admin */
+	if ( is_admin() ) {
+
+		/** First, look in WordPress' "languages" folder (update-safe) */
+		load_textdomain(
+			$sh_textdomain,
+			$sh_wp_lang_dir
+		);
+
+		/** Secondly, look in plugin's "languages" (default) */
+		load_plugin_textdomain(
+			$sh_textdomain,
+			FALSE,
+			trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) . 'languages'
+		);
+
+	}
+
+}
 
 register_activation_hook( __FILE__, 'simplehooks_activation' );
 /**
@@ -42,7 +86,7 @@ function simplehooks_activation() {
 function simplehooks_deactivate( $genesis_version = '2.1.0', $wp_version = '3.9.2' ) {
 	
 	deactivate_plugins( plugin_basename( __FILE__ ) );
-	wp_die( sprintf( __( 'Sorry, you cannot run Simple Hooks without WordPress %s and <a href="%s">Genesis %s</a>, or greater.', 'simplehooks' ), $wp_version, 'http://my.studiopress.com/?download_id=91046d629e74d525b3f2978e404e7ffa', $genesis_version ) );
+	wp_die( sprintf( __( 'Sorry, you cannot run Simple Hooks without WordPress %s and <a href="%s">Genesis %s</a>, or greater.', 'genesis-simple-hooks' ), $wp_version, 'http://my.studiopress.com/?download_id=91046d629e74d525b3f2978e404e7ffa', $genesis_version ) );
 	
 }
 


### PR DESCRIPTION
- Unify text domain to plugin’s slug (= "genesis-simple-hooks")
- Add text domain loading function
- Improve one printf() string placeholder
- Add default .pot file for translators
