### PR TITLE
Allow CircleCI to bump the 'Tested up to' version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,39 @@ jobs:
       - checkout
       - prepare-environment
       - run: composer phpcs
+  svn-deploy-bump-tested-up-to:
+    docker:
+      - image: cimg/base:2022.04
+    steps:
+      - checkout:
+          path: /tmp/src
+      - run:
+          name: Deploying only the 'Tested up to' bump to SVN
+          command: |
+            sudo apt-get update
+            sudo apt-get install subversion
+            SLUG=genesis-responsive-slider
+            VERSION=$(grep -i 'Version:' "/tmp/src/$SLUG.php" | awk -F: '{print $2}' | sed 's/^\s//')
+            if [ ! $VERSION ]
+              then
+              echo "Didn't find a version of the plugin"
+              exit 1
+            fi
+            TESTED_UP_TO_VERSION=$(grep -i 'tested up to:' /tmp/src/readme.txt | awk -F: '{print $2}' | sed 's/^\s//')
+            if [ ! $TESTED_UP_TO_VERSION ]
+              then
+              echo "Didn't find a 'Tested up to' version, so can't bump it"
+              exit 1
+            fi
+            svn co https://plugins.svn.wordpress.org/${SLUG} --depth=empty .
+            svn up trunk
+            svn up tags --depth=empty
+            svn up tags/${VERSION}
+            sed -i "s/tested up to: .*/Tested up to: ${TESTED_UP_TO_VERSION}/i" trunk/readme.txt tags/${VERSION}/readme.txt
+            echo "Here is the svn stat about to be checked in:"
+            svn stat
+            echo "And here is the diff:"
+            svn diff
 
 commands:
  prepare-environment:
@@ -20,3 +53,15 @@ workflows:
   check-wp-cs:
     jobs:
       - test
+      - approval-for-svn-deploy-bump-tested-up-to:
+          type: approval
+          requires:
+            - test
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /^bump-tested-up-to.*/
+      - svn-deploy-bump-tested-up-to:
+          requires:
+            - approval-for-svn-deploy-bump-tested-up-to

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.2
-Tested up to: 5.4
+Tested up to: 5.9
 Stable tag: 2.3.0
 
 This plugin creates a new Genesis settings page that allows you to insert code (HTML, Shortcodes, and PHP), and attach it to any of the 50+ action hooks throughout the Genesis Theme Framework, from StudioPress.


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->
Allow CircleCI to bump the 'Tested up to' versions

<!-- Fixes #xxx. -->
<!-- See #xxx. -->

### How to test
<!-- Detailed steps to test this PR. -->
1. When CircleCI is activated for this repo again, verify that the `svn stat` and `svn diff` are as expected
2. This won't deploy yet, it doesn't have `svn ci` 

### Documentation
No documentation required. 
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
- Allow CircleCI to bump the 'Tested up to' versions


<!-- Additional information for reviewers. -->
### Notes
Basically a copy-paste of https://github.com/studiopress/genesis-responsive-slider/pull/23