### PR TITLE
ci: reinstate 'tested up to' deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,23 +2,23 @@ version: 2.1
 
 orbs:
   php: circleci/php@1.0
-  # wp-svn: studiopress/wp-svn@0.1
+  wp-svn: studiopress/wp-svn@0.1
 
 workflows:
   test-deploy:
     jobs:
       - php/test:
           test-command: phpcs
-      # - approval-for-deploy-tested-up-to-bump:
-      #     requires: 
-      #       - php/test
-      #     type: approval
-      #     filters:
-      #       tags:
-      #         ignore: /.*/
-      #       branches:
-      #         only: /^bump-tested-up-to.*/
-      # - wp-svn/deploy-tested-up-to-bump:
-      #     context: genesis-svn
-      #     requires:
-      #       - approval-for-deploy-tested-up-to-bump
+      - approval-for-deploy-tested-up-to-bump:
+          requires:
+            - php/test
+          type: approval
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /^bump-tested-up-to.*/
+      - wp-svn/deploy-tested-up-to-bump:
+          context: genesis-svn
+          requires:
+            - approval-for-deploy-tested-up-to-bump


### PR DESCRIPTION
WP.org is no longer blocked, we can deploy 'tested up to' updates this way again.