### PR TITLE
[LOC-6863] Fix "translation loading triggered too early" warning

### DIFF
--- a/includes/class-genesis-simple-hooks-admin.php
+++ b/includes/class-genesis-simple-hooks-admin.php
@@ -131,8 +131,6 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 		// For backward compatibility.
 		define( 'SIMPLEHOOKS_SETTINGS_FIELD', $this->settings_field );
 
-		$this->define_hooks();
-
 	}
 
 	/**
@@ -142,6 +140,8 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 	 */
 	public function init() {
 
+		add_action( 'init', array( $this, 'define_hooks' ) );
+		add_action( 'init', array( $this, 'set_default_settings' ) );
 		add_action( 'genesis_admin_menu', array( $this, 'admin_menu' ) );
 
 	}
@@ -167,8 +167,19 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 			'screen_icon' => 'plugins',
 		);
 
-		// Create the page.
-		$this->create( $page_id, $menu_ops, $page_ops, $this->settings_field, $this->get_default_settings() );
+		// Create the page. Default settings are set separately on init.
+		$this->create( $page_id, $menu_ops, $page_ops, $this->settings_field );
+
+	}
+
+	/**
+	 * Set default settings property after hooks are defined.
+	 *
+	 * @since 2.3.2
+	 */
+	public function set_default_settings() {
+
+		$this->default_settings = $this->get_default_settings();
 
 	}
 

--- a/includes/class-genesis-simple-hooks.php
+++ b/includes/class-genesis-simple-hooks.php
@@ -102,8 +102,6 @@ class Genesis_Simple_Hooks {
 	 */
 	public function init() {
 
-		$this->load_plugin_textdomain();
-
 		add_action( 'admin_notices', array( $this, 'requirements_notice' ) );
 
 		// Because this is a Genesis-dependent plugin.
@@ -135,14 +133,6 @@ class Genesis_Simple_Hooks {
 
 	}
 
-	/**
-	 * Load the plugin textdomain, for translation.
-	 *
-	 * @since 2.2.0
-	 */
-	public function load_plugin_textdomain() {
-		load_plugin_textdomain( 'genesis-simple-hooks', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
-	}
 
 	/**
 	 * All general includes.


### PR DESCRIPTION
Fixes this warning visible in PHP logs when visiting any admin page:

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the genesis-simple-hooks
domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early.
Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This
message was added in version 6.7.0.) in /Users/user.name/Local Sites/genesisqa/app/public/wp-includes/functions.php on
line 6170
```

### How to test

Tested under WP 7.0beta5 with Genesis and Genesis Sample active, and this in `wp-config.php`:

```php
if ( ! defined( 'WP_DEBUG' ) ) {
        define( 'WP_DEBUG', true );
}

if ( ! defined( 'WP_DEBUG_LOG' ) ) {
        define( 'WP_DEBUG_LOG', true );
}
```

Check that:

1. No PHP warning in logs
Visit any admin page and confirm the "translation loading triggered too early" notice is gone from the PHP error log.

2. Simple Hooks admin page loads correctly
- Go to Genesis → Simple Hooks in wp-admin.
- Confirm the page renders down to the submit buttons at the bottom.

3. Settings save and persist
- Add some content to any hook field (e.g. genesis_before_header), for example:
    ```
    <p>Unix time is <?php echo time(); ?> </p>
    ```

    <img width="722" height="662" alt="CleanShot 2026-03-19 at 17 16 15@2x" src="https://github.com/user-attachments/assets/f088d37b-ea3b-4919-9d08-58f020310a1e" />


- Save — confirm the success notice appears
- Reload the page — confirm the content is still there

4. Saved hooks actually execute on the front end
- Check that the HTML you added to genesis_before_header appears on the front end of the site (before the header):

    <img width="844" height="288" alt="CleanShot 2026-03-19 at 17 16 45@2x" src="https://github.com/user-attachments/assets/f1a1f985-7646-4015-a240-13b5346be458" />


5. Reset settings works
- Press Reset Settings at the bottom of the Genesis → Simple Hooks admin page and confirm it clears to defaults (empty values) without errors:

    <img width="732" height="642" alt="CleanShot 2026-03-19 at 17 17 29@2x" src="https://github.com/user-attachments/assets/0fb00ddd-1a14-4d7d-affe-84996d46ed59" />

6. Optionally confirm that the text domain still loads and translations work for the plugin.

I did it like this:

```sh
# Create a minimal French translation file
cd wp-content
mkdir -p languages/plugins
echo 'msgid "Simple Hooks"\nmsgstr "Simple Hooks TEST"' > languages/plugins/genesis-simple-hooks-fr_FR.po
msgfmt languages/plugins/genesis-simple-hooks-fr_FR.po -o languages/plugins/genesis-simple-hooks-fr_FR.mo 

# Change site language to French
wp language core install fr_FR
wp option update WPLANG fr_FR --autoload=yes


# Now refresh any WP admin page.
# Check the admin sidebar reads "Genesis Hooks TEST" under "Genesis"

# Clean up: reset lang to English US
wp option update WPLANG ''
```

<img width="722" height="182" alt="CleanShot 2026-03-19 at 17 12 41@2x" src="https://github.com/user-attachments/assets/7ee4da42-e6f6-48ca-bdd2-b763b6d4be11" />

### Documentation
No documentation required.

### Reference
https://wpengine.atlassian.net/browse/LOC-6863
