### PR TITLE
Support tag and deploy to WP.org via SVN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   php: circleci/php@1.0
   node: circleci/node@5.0
-  wp-svn: studiopress/wp-svn@0.1
+  wp-svn: studiopress/wp-svn@0.2
 
 executors:
   node-only:
@@ -51,6 +51,16 @@ jobs:
           path: build/wpe/info.json
           destination: info.json
 
+  svn_deploy_tag:
+    docker:
+      - image: cimg/base:current
+    working_directory: ~/project
+    steps:
+      - checkout:
+          path: genesis-simple-hooks
+      - wp-svn/deploy-plugin:
+          plugin-path: genesis-simple-hooks
+
 workflows:
   test-deploy:
     jobs:
@@ -68,6 +78,22 @@ workflows:
               only: /.*/
           requires:
             - zip
+      - wp-svn/check-versions:
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              only: /^release\/.*/
+      - svn_deploy_tag:
+          context: genesis-svn
+          requires:
+            - zip
+            - wp-svn/check-versions
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
       - approval-for-deploy-tested-up-to-bump:
           requires:
             - php/test


### PR DESCRIPTION
Follows the pattern we use in other plugins, such as [Genesis Blocks](https://github.com/studiopress/genesis-blocks/blob/develop/.circleci/config.yml).

### How to test
Code review.

The [genesis-svn context](https://app.circleci.com/settings/organization/github/studiopress/contexts/9c7ec3e3-e629-4285-abd8-de595fedbcb0?return-to=https%3A%2F%2Fapp.circleci.com%2Fjobs%2Fgithub%2Fstudiopress%2Fgenesis-simple-hooks%2F124) is already set in Circle and provides required SVN credentials.

To deploy after this is merged, re-tag the develop branch with 2.3.2 (for example, by deleting the current 2.3.2 release and tag and making a new release). Release requires manual approval in WP.org (I have auth info).
